### PR TITLE
[#1] CI를 추가합니다.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build
         run: |
-          xcodebuild clean build-for-testing \
+          xcodebuild build-for-testing \
             -workspace "$WORKSPACE" \
             -scheme "$SCHEME" \
             -destination "$DESTINATION" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: macos-latest
+    env:
+      WORKSPACE: "App/Alarmed.xcworkspace"
+      SCHEME: "Alarmed"
+      DESTINATION: "platform=iOS Simulator,name=iPhone 16,OS=latest"
+      COMMON_FLAGS: "-skipPackagePluginValidation -skipMacroValidation"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build
+        run: |
+          xcodebuild clean build-for-testing \
+            -workspace "$WORKSPACE" \
+            -scheme "$SCHEME" \
+            -destination "$DESTINATION" \
+            $COMMON_FLAGS | xcpretty
+
+      - name: Test
+        run: |
+          xcodebuild test-without-building \
+            -workspace "$WORKSPACE" \
+            -scheme "$SCHEME" \
+            -destination "$DESTINATION" \
+            $COMMON_FLAGS | xcpretty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: macos-latest
+    runs-on: macos-15
     env:
       WORKSPACE: "App/Alarmed.xcworkspace"
       SCHEME: "Alarmed"
@@ -19,6 +19,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup Xcode version to latest stable
+        uses: maxim-lobanov/setup-xcode@v1.6.0
+        with:
+          xcode-version: latest-stable
 
       - name: Build
         run: |

--- a/App/Alarmed.xcodeproj/xcshareddata/xcschemes/Alarmed.xcscheme
+++ b/App/Alarmed.xcodeproj/xcshareddata/xcschemes/Alarmed.xcscheme
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA7BD7342D6AE6830079A8C6"
+               BuildableName = "Alarmed.app"
+               BlueprintName = "Alarmed"
+               ReferencedContainer = "container:Alarmed.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:iOS/Resources/Alarmed.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA7BD7342D6AE6830079A8C6"
+            BuildableName = "Alarmed.app"
+            BlueprintName = "Alarmed"
+            ReferencedContainer = "container:Alarmed.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA7BD7342D6AE6830079A8C6"
+            BuildableName = "Alarmed.app"
+            BlueprintName = "Alarmed"
+            ReferencedContainer = "container:Alarmed.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/App/iOS/Resources/Alarmed.xctestplan
+++ b/App/iOS/Resources/Alarmed.xctestplan
@@ -1,0 +1,31 @@
+{
+  "configurations" : [
+    {
+      "id" : "8F676EC9-C599-41B5-9898-7750007A8D63",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:..\/Features",
+        "identifier" : "AppFeatureTests",
+        "name" : "AppFeatureTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Features",
+        "identifier" : "AlarmFeatureTests",
+        "name" : "AlarmFeatureTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Features/Package.swift
+++ b/Features/Package.swift
@@ -65,7 +65,8 @@ private var targets: [Target] {
       module: .AppFeature,
       dependencies: [
         .module(.AlarmFeature),
-      ]),
+      ],
+      addTestTarget: true),
     Target.module(
       module: .ResourcePackage,
       resources: [

--- a/Features/Sources/AlarmFeature/Edit/AlarmEditView.swift
+++ b/Features/Sources/AlarmFeature/Edit/AlarmEditView.swift
@@ -26,7 +26,9 @@ public struct AlarmEditView: View {
           "Alarm Time Picker",
           selection: $store.alarmTime,
           displayedComponents: .hourAndMinute)
-          .datePickerStyle(.wheel)
+          #if os(iOS)
+            .datePickerStyle(.wheel)
+          #endif
           .labelsHidden()
       }
 

--- a/Features/Tests/AppFeatureTests/AppFeatureTests.swift
+++ b/Features/Tests/AppFeatureTests/AppFeatureTests.swift
@@ -1,0 +1,12 @@
+//
+//  AppFeatureTests.swift
+//  Features
+//
+//  Created by Geonhee on 3/16/25.
+//
+
+import Testing
+@testable import AppFeature
+
+@Test
+func appFeatureTests() async throws { }


### PR DESCRIPTION
# 1. 작업 사항
1. main branch 대상으로 PR 발생 시 CI 트리거
2. Swift 6 컴파일러를 지원하는 Xcode 16 이상의 runner image를 이용하기 위해 macos-latest (macos-13) 대신 macos-15로 최신 OS를 타겟팅함.
3. Alarmed 앱 타겟에 xctestplan 설정하여 의존하는 Swift Package의 Test 타겟 실행 보장